### PR TITLE
Pip 734 upgrade tc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,9 @@ RUN python3.7 -m pip install qc-utils==19.8.1
 
 RUN python3.7 -m pip install pandas scipy
 
-# Get transcriptclean v1.0.7
+# Get transcriptclean v1.0.8
 
-RUN git clone -b 'v1.0.7' --single-branch https://github.com/dewyman/TranscriptClean.git
+RUN git clone -b 'v1.0.8' --single-branch https://github.com/dewyman/TranscriptClean.git
 RUN chmod 755 TranscriptClean/accessory_scripts/* TranscriptClean/TranscriptClean.py TranscriptClean/generate_report.R
 ENV PATH "/software/TranscriptClean/accessory_scripts:/software/TranscriptClean:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ RUN mkdir /software
 WORKDIR /software
 ENV PATH="/software:${PATH}"
 
+# Install samtools dependency
+
+RUN wget https://tukaani.org/xz/xz-5.2.3.tar.gz && tar -xvf xz-5.2.3.tar.gz
+RUN cd xz-5.2.3 && ./configure && make && make install && rm ../xz-5.2.3.tar.gz
+
 # Install minimap2
 
 RUN curl -L https://github.com/lh3/minimap2/releases/download/v2.15/minimap2-2.15_x64-linux.tar.bz2 | tar -jxvf -
@@ -66,11 +71,6 @@ RUN python3.7 -m pip install pandas scipy
 RUN git clone -b 'v1.0.8' --single-branch https://github.com/dewyman/TranscriptClean.git
 RUN chmod 755 TranscriptClean/accessory_scripts/* TranscriptClean/TranscriptClean.py TranscriptClean/generate_report.R
 ENV PATH "/software/TranscriptClean/accessory_scripts:/software/TranscriptClean:${PATH}"
-
-# Install samtools dependency
-
-RUN wget https://tukaani.org/xz/xz-5.2.3.tar.gz && tar -xvf xz-5.2.3.tar.gz
-RUN cd xz-5.2.3 && ./configure && make && make install && rm ../xz-5.2.3.tar.gz
 
 # Install samtools 1.9
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -23,7 +23,7 @@ Transcriptclean runs on python 2.7, and other parts utilize 3.7.
 
 [Minimap2](https://github.com/lh3/minimap2) is a versatile sequence alignment program that aligns DNA or mRNA sequences against a large reference database. For publication describing the software in detail, see [Paper by Li, H](https://doi.org/10.1093/bioinformatics/bty191).
 
-### Transcriptclean v1.0.7
+### Transcriptclean v1.0.8
 
 [Transcriptclean](https://github.com/dewyman/TranscriptClean) is a program that corrects for mismatches, microindels and non-canonical splice junctions. For publication describing the software in detail, see [Paper by Dana Wyman, Ali Mortazavi](https://doi.org/10.1093/bioinformatics/bty483).
 

--- a/test/test_task/test_transcriptclean_reference_md5.json
+++ b/test/test_task/test_transcriptclean_reference_md5.json
@@ -1,6 +1,6 @@
 {
     "TEST_TRANSCRIPTCLEAN_clean.log" : "0cac2cb51ba1839eaeb1078201aea191",
     "TEST_TRANSCRIPTCLEAN_clean.TE.log" : "2dabfde5147e9cef8964334f52b13622",
-    "TEST_TRANSCRIPTCLEAN_clean.fa" : "de1c66dfb4cc8d0a2572800761dc83a7",
-    "TEST_TRANSCRIPTCLEAN_noheader_clean.sam" : "9e3a06cdf888faaf3a6836b385edc778"
+    "TEST_TRANSCRIPTCLEAN_clean.fa" : "d72fd30a4e0be28ddaff3713bf7a6b7b",
+    "TEST_TRANSCRIPTCLEAN_noheader_clean.sam" : "a39dc5d6661c20a51bab192c2419430a"
 }


### PR DESCRIPTION
Dana Wyman reported a bug in the transcriptclean version 1.0.7, which she has released a fix for in the version 1.0.8 that I upgraded into. Because this PR changes the Dockerfile, I sneaked in a small improvement by moving the rarely changed xz installation up a notch.